### PR TITLE
Move addBladeDirectives to boot and change to callAfterResolving

### DIFF
--- a/src/FormServiceProvider.php
+++ b/src/FormServiceProvider.php
@@ -30,6 +30,7 @@ class FormServiceProvider extends ServiceProvider
 		  __DIR__.'/resources/views' => resource_path('views/vendor/form'),
 		],'form');
 
+        $this->addBladeDirectives();
     }
 
     public function register(){
@@ -39,13 +40,11 @@ class FormServiceProvider extends ServiceProvider
 			$formlet->setRequest($app['request']);
             $formlet->initialize();
 		});
-
-        $this->addBladeDirectives();
 	}
 
     protected function addBladeDirectives(): void
     {
-        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+        $this->callAfterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
 
             $bladeCompiler->aliasComponent('form::components.form','form');
 


### PR DESCRIPTION
Moves addBladeDirectives to boot function as recommended by Mr Ottwell, and changes to use callAfterResolving, again as recommended. This is due to random issue that can come in package compability when the order of service provider registration changes internall within Laravel

As discussed with Param and recommended in long thread on the issue on Laravel core, when using $this->app->afterResolving() it can cause random issue that can come in package compability when the order of service provider registration changes internall within Laravel - the blade directives are then not registered, and you just get the following on page:

<img width="118" alt="rs-form-directive-not-loaded" src="https://github.com/RedSnapper/LaravelForm/assets/13349485/fdbfe953-8d98-4e8f-939a-171e9833481f">


Spatie package encountered same issue: https://github.com/spatie/laravel-permission/pull/2048

And Ottwell's comment here: https://github.com/laravel/framework/pull/41397#issuecomment-1062223510

Telling user that Blade Directives should be in boot not register, and to use callAfterResolving.